### PR TITLE
Fix for ekalappai issue #16 : thamizha.com url removed

### DIFF
--- a/_posts/2010-11-19-ekalappai-v3.md
+++ b/_posts/2010-11-19-ekalappai-v3.md
@@ -29,7 +29,6 @@ Tamil99 and Tamil-typewriter keymaps are made so as to near fully conform to Tam
 eKalappai 3.0 can be downloaded in the following URLs:
 ------------------------------------------------------
 <ul>
-	<li><a href="http://thamizha.com/project/ekalappai">http://thamizha.com/project/ekalappai</a></li>
 	<li><a href="http://code.google.com/p/ekalappai/downloads/list">http://code.google.com/p/ekalappai/downloads/list</a></li>
 </ul>
 

--- a/_posts/2011-01-15-android-tamilvisai-v1.md
+++ b/_posts/2011-01-15-android-tamilvisai-v1.md
@@ -27,7 +27,6 @@ If you are a developer and like to contribute to development you can check this 
 
 If you like to discuss about development and new features you can either use the following:
 * Google group: http://groups.google.com/group/freetamilcomputing
-* Disussion forum: http://thamizha.com/forum
 
 I thank Jegadesan & all other members of thamizha.com team who have contributed to this project.
 


### PR DESCRIPTION
Greetings,

in our thamizha.org website, there are two links which points to thamizha.com which have been marked as spam. So it should be removed, so that our thamizha.org can be excluded from spam. 
I have removed the link. One of the link which points to forum has no alternative. so it needs to be discussed.
The other link points to ekalappai v3 download page which has an alternative to google.code.com so there is no need to worry about.

Please accept my pull request.

with regards,
g.vijay
